### PR TITLE
feat!: bill on beginning of period & billing period based on start date instead of months

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+cd ~ || exit
+
+sudo apt update && sudo apt install redis-server libcups2-dev
+
+pip install frappe-bench
+
+git clone https://github.com/frappe/frappe --branch version-15 --depth 1
+bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
+
+mysql --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
+mysql --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
+
+mysql --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE USER 'test_frappe'@'localhost' IDENTIFIED BY 'test_frappe'"
+mysql --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE DATABASE test_frappe"
+mysql --host 127.0.0.1 --port 3306 -u root -proot -e "GRANT ALL PRIVILEGES ON \`test_frappe\`.* TO 'test_frappe'@'localhost'"
+
+mysql --host 127.0.0.1 --port 3306 -u root -proot -e "FLUSH PRIVILEGES"
+
+cd ~/frappe-bench || exit
+
+sed -i 's/watch:/# watch:/g' Procfile
+sed -i 's/schedule:/# schedule:/g' Procfile
+sed -i 's/socketio:/# socketio:/g' Procfile
+sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
+
+bench get-app payments --branch version-15
+bench get-app erpnext --branch version-15
+bench get-app simple_subscription "${GITHUB_WORKSPACE}"
+
+bench start &> bench_run_logs.txt &
+bench new-site --db-root-password root --admin-password admin test_site --install-app erpnext
+bench --site test_site install-app simple_subscription
+bench setup requirements --dev

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,16 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ version-13 ]
+    branches: [ version-* ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ version-13 ]
-  schedule:
-    - cron: '34 13 * * 0'
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -32,17 +28,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'python' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        language: [ 'javascript-typescript', 'python' ]
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,21 +44,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -1,0 +1,89 @@
+
+name: Server
+
+on:
+  push:
+    branches:
+      - version-14
+      - version-15
+  pull_request:
+
+concurrency:
+  group: version-15-simple_subscription-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      NODE_ENV: "production"
+
+    strategy:
+      fail-fast: false
+
+    services:
+      mariadb:
+        image: mariadb:10.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          check-latest: true
+
+      - name: Add to Hosts
+        run: |
+          echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: 'echo "::set-output name=dir::$(yarn cache dir)"'
+
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install
+        run: |
+          bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
+
+      - name: Run Tests
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench --site test_site set-config allow_tests true
+          bench --site test_site run-tests --app simple_subscription
+        env:
+          TYPE: server
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: cat ~/frappe-bench/bench_start.log || true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Easy setup: existing **Subscriptions** get copied from ERPNext (you have to canc
 1. Create a new **Simple Subscription**
 2. Select a _Customer_
 3. Set a _Start Date_
+4. Select if billing is based on _calendar months_ or _Start Date_
+5. Select if billing is supposed to happen _at the beginning of period_ or _after end of period_
 4. Select a _Frequency_
 5. Add items to the table
 6. Select a _Sales Taxes and Charges Template_
@@ -16,8 +18,8 @@ Easy setup: existing **Subscriptions** get copied from ERPNext (you have to canc
 
 - Submit a **Simple Subscription** to start generating invoices.
 
-    - New invoices will automatically be generated on the first day of a period, for the previous period.
-    - If you need an invoice immediately, click the button "Create last {Monthly / Quarterly / Yearly} invoice".
+    - New invoices for the current period will automatically be generated once per day if they don't yet exist
+    - If you need an invoice immediately, click the button "Create current {Monthly / Quarterly / Yearly} invoice".
 
 - Mark a **Simple Subscription** as _disabled_ to stop generating invoices.
 - Duplicate a disabled **Simple Subscription** to change any values.

--- a/simple_subscription/hooks.py
+++ b/simple_subscription/hooks.py
@@ -116,7 +116,7 @@ scheduler_events = {
 # Testing
 # -------
 
-# before_tests = "simple_subscription.install.before_tests"
+before_tests = "simple_subscription.utils.before_tests"
 
 # Overriding Methods
 # ------------------------------

--- a/simple_subscription/install.py
+++ b/simple_subscription/install.py
@@ -5,7 +5,7 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from simple_subscription.simple_subscription.doctype.simple_subscription.simple_subscription import (
 	Frequency,
-	get_first_day_of_period
+	get_calendar_period
 )
 
 
@@ -52,7 +52,7 @@ def create_simple_subscription(
 ):
 	simple_subscription = frappe.new_doc("Simple Subscription")
 	simple_subscription.customer = customer
-	simple_subscription.start_date = get_first_day_of_period(date.today(), frequency)
+	simple_subscription.start_date, _ = get_calendar_period(date.today(), frequency)
 	simple_subscription.frequency = frequency.name
 	simple_subscription.extend("items", items)
 	simple_subscription.taxes_and_charges = taxes_and_charges

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.js
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.js
@@ -32,7 +32,7 @@ frappe.ui.form.on("Simple Subscription", {
 		frm.add_custom_button(__("Create last {0} invoice", [translated_frequency]), () =>
 			frappe.call({
 				method:
-					"simple_subscription.simple_subscription.doctype.simple_subscription.simple_subscription.create_invoice_for_previous_period",
+					"simple_subscription.simple_subscription.doctype.simple_subscription.simple_subscription.create_current_invoice",
 				args: {
 					subscription_name: frm.doc.name,
 				},

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.js
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.js
@@ -29,7 +29,7 @@ frappe.ui.form.on("Simple Subscription", {
 			null,
 			"Frequency of Subscription"
 		);
-		frm.add_custom_button(__("Create last {0} invoice", [translated_frequency]), () =>
+		frm.add_custom_button(__("Create current {0} invoice", [translated_frequency]), () =>
 			frappe.call({
 				method:
 					"simple_subscription.simple_subscription.doctype.simple_subscription.simple_subscription.create_current_invoice",

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.json
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.json
@@ -11,6 +11,7 @@
   "customer_name",
   "column_break_3",
   "start_date",
+  "billing_time",
   "frequency",
   "disabled",
   "section_break_5",
@@ -95,6 +96,13 @@
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company"
+  },
+  {
+   "default": "after end of period",
+   "fieldname": "billing_time",
+   "fieldtype": "Select",
+   "label": "Billing Time",
+   "options": "at beginning of period\nafter end of period"
   }
  ],
  "is_submittable": 1,
@@ -104,7 +112,7 @@
    "link_fieldname": "simple_subscription"
   }
  ],
- "modified": "2024-07-30 12:12:07.652994",
+ "modified": "2024-08-20 17:39:07.518351",
  "modified_by": "Administrator",
  "module": "Simple Subscription",
  "name": "Simple Subscription",

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.json
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.json
@@ -11,6 +11,7 @@
   "customer_name",
   "column_break_3",
   "start_date",
+  "period_type",
   "billing_time",
   "frequency",
   "disabled",
@@ -103,6 +104,13 @@
    "fieldtype": "Select",
    "label": "Billing Time",
    "options": "at beginning of period\nafter end of period"
+  },
+  {
+   "default": "calendar months",
+   "fieldname": "period_type",
+   "fieldtype": "Select",
+   "label": "Billing Period is based on",
+   "options": "calendar months\nstart date"
   }
  ],
  "is_submittable": 1,
@@ -112,7 +120,7 @@
    "link_fieldname": "simple_subscription"
   }
  ],
- "modified": "2024-08-20 17:39:07.518351",
+ "modified": "2024-08-20 20:19:15.055024",
  "modified_by": "Administrator",
  "module": "Simple Subscription",
  "name": "Simple Subscription",

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
@@ -84,7 +84,7 @@ def create_current_invoice(subscription_name: str, silent=False):
 			)
 
 	if (
-		subscription.billing_time == "after end of period"
+		subscription.billing_time != "at beginning of period"
 		and subscription.start_date > from_date
 	):
 		if not silent:

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
@@ -65,7 +65,8 @@ def create_current_invoice(subscription_name: str, silent=False):
 			from_date, to_date = current_period_start, current_period_end
 		else:
 			from_date, to_date = get_calendar_period(current_period_start - timedelta(days=1), frequency)
-	if subscription.period_type == "start date":
+
+	else:
 		current_period_start, current_period_end = get_date_period(date.today(), frequency, subscription.start_date)
 		if subscription.billing_time == "at beginning of period" :
 			from_date, to_date = current_period_start, current_period_end
@@ -73,11 +74,10 @@ def create_current_invoice(subscription_name: str, silent=False):
 			from_date, to_date = get_date_period(current_period_start - timedelta(days=1), frequency, subscription.start_date)
 	
 	
-
-	if subscription.start_date > from_date:
+	if (subscription.billing_time == "after end of period" and subscription.start_date > from_date):
 		if not silent:
 			frappe.throw(
-				_("Subscription started after the first day of the last period.")
+				_(f"Subscription started after the first day of the last period({from_date}).")
 			)
 		return
 

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
@@ -77,7 +77,13 @@ def create_current_invoice(subscription_name: str, silent=False):
 	if (subscription.billing_time == "after end of period" and subscription.start_date > from_date):
 		if not silent:
 			frappe.throw(
-				_(f"Subscription started after the first day of the last period({from_date}).")
+				_(f"Subscription starts after the first day of the current period({from_date}).")
+			)
+		return
+	elif (subscription.billing_time == "at beginning of period" and subscription.start_date > to_date):
+		if not silent:
+			frappe.throw(
+				_(f"Subscription started after the last day of the current period({to_date}).")
 			)
 		return
 

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
@@ -139,7 +139,11 @@ def get_existing_sales_invoice(
 def get_active_subscriptions():
 	return frappe.get_all(
 		"Simple Subscription",
-		filters={"docstatus": 1, "disabled": ("!=", 1)},
+		filters={
+			"docstatus": 1,
+			"disabled": ("!=", 1),
+			"start_date": ("<=", date.today()),
+		},
 		pluck="name",
 	)
 

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/simple_subscription.py
@@ -60,30 +60,49 @@ def create_current_invoice(subscription_name: str, silent=False):
 
 	# determine current billing period based on period_type and billing_time
 	if subscription.period_type == "calendar months":
-		current_period_start, current_period_end = get_calendar_period(date.today(), frequency)
-		if subscription.billing_time == "at beginning of period" :
+		current_period_start, current_period_end = get_calendar_period(
+			date.today(), frequency
+		)
+		if subscription.billing_time == "at beginning of period":
 			from_date, to_date = current_period_start, current_period_end
 		else:
-			from_date, to_date = get_calendar_period(current_period_start - timedelta(days=1), frequency)
+			from_date, to_date = get_calendar_period(
+				current_period_start - timedelta(days=1), frequency
+			)
 
 	else:
-		current_period_start, current_period_end = get_date_period(date.today(), frequency, subscription.start_date)
-		if subscription.billing_time == "at beginning of period" :
+		current_period_start, current_period_end = get_date_period(
+			date.today(), frequency, subscription.start_date
+		)
+		if subscription.billing_time == "at beginning of period":
 			from_date, to_date = current_period_start, current_period_end
 		else:
-			from_date, to_date = get_date_period(current_period_start - timedelta(days=1), frequency, subscription.start_date)
-	
-	
-	if (subscription.billing_time == "after end of period" and subscription.start_date > from_date):
+			from_date, to_date = get_date_period(
+				current_period_start - timedelta(days=1),
+				frequency,
+				subscription.start_date,
+			)
+
+	if (
+		subscription.billing_time == "after end of period"
+		and subscription.start_date > from_date
+	):
 		if not silent:
 			frappe.throw(
-				_(f"Subscription starts after the first day of the current period({from_date}).")
+				_(
+					f"Subscription starts after the first day of the current period({from_date})."
+				)
 			)
 		return
-	elif (subscription.billing_time == "at beginning of period" and subscription.start_date > to_date):
+	elif (
+		subscription.billing_time == "at beginning of period"
+		and subscription.start_date > to_date
+	):
 		if not silent:
 			frappe.throw(
-				_(f"Subscription started after the last day of the current period({to_date}).")
+				_(
+					f"Subscription started after the last day of the current period({to_date})."
+				)
 			)
 		return
 
@@ -129,6 +148,7 @@ def get_active_subscriptions():
 		pluck="name",
 	)
 
+
 def get_calendar_period(eval_date: date, frequency: Frequency) -> Tuple[date, date]:
 	"""Return the first day and last day of the period containing `from_date`."""
 	invoice_month_map = {
@@ -141,32 +161,50 @@ def get_calendar_period(eval_date: date, frequency: Frequency) -> Tuple[date, da
 		Frequency.Monthly: 1,
 		Frequency.Quarterly: 3,
 		Frequency.Halfyearly: 6,
-		Frequency.Yearly: 12
+		Frequency.Yearly: 12,
 	}
 
-	from_date = eval_date.replace(day=1, month= invoice_month_map[frequency][eval_date.month - 1])
-	to_date = from_date + relativedelta(months= no_of_month_map[frequency]) - relativedelta(days=1)
+	from_date = eval_date.replace(
+		day=1, month=invoice_month_map[frequency][eval_date.month - 1]
+	)
+	to_date = (
+		from_date
+		+ relativedelta(months=no_of_month_map[frequency])
+		- relativedelta(days=1)
+	)
 
 	return from_date, to_date
 
-def get_date_period(eval_date: date, frequency: Frequency, initial_date: date) -> Tuple[date, date]:
 
+def get_date_period(
+	eval_date: date, frequency: Frequency, initial_date: date
+) -> Tuple[date, date]:
 	no_of_month_map = {
 		Frequency.Monthly: 1,
 		Frequency.Quarterly: 3,
 		Frequency.Halfyearly: 6,
-		Frequency.Yearly: 12
+		Frequency.Yearly: 12,
 	}
-	
-	delta = relativedelta(eval_date , initial_date)
 
-	 # determine no of period eval_date lies in when starting on initial_date
+	delta = relativedelta(eval_date, initial_date)
+
+	# determine no of period eval_date lies in when starting on initial_date
 	if eval_date >= initial_date:
-		month_detla_floor = (delta.years * 12 + delta.months) // no_of_month_map[frequency]
+		month_detla_floor = (delta.years * 12 + delta.months) // no_of_month_map[
+			frequency
+		]
 	else:
-		month_detla_floor = (delta.years * 12 + delta.months - 1) // no_of_month_map[frequency] 
+		month_detla_floor = (delta.years * 12 + delta.months - 1) // no_of_month_map[
+			frequency
+		]
 
-	from_date = initial_date + relativedelta(months= (no_of_month_map[frequency] * month_detla_floor))	
-	to_date = from_date + relativedelta(months= no_of_month_map[frequency]) - relativedelta(days=1)
+	from_date = initial_date + relativedelta(
+		months=(no_of_month_map[frequency] * month_detla_floor)
+	)
+	to_date = (
+		from_date
+		+ relativedelta(months=no_of_month_map[frequency])
+		- relativedelta(days=1)
+	)
 
 	return from_date, to_date

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/test_simple_subscription.py
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/test_simple_subscription.py
@@ -32,7 +32,7 @@ class TestSimpleSubscription(unittest.TestCase):
 		self.assertEqual(from_date, date(2022, 1, 1))
 		self.assertEqual(to_date, date(2022, 12, 31))
 
-def test_get_date_period(self):
+	def test_get_date_period(self):
 		eval_date = date(2022, 11, 7)
 		initial_date = date(2022, 6, 25)
 

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/test_simple_subscription.py
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/test_simple_subscription.py
@@ -6,23 +6,49 @@ import unittest
 from datetime import date
 
 from .simple_subscription import (
-	get_first_day_of_period,
+	get_calendar_period,
+	get_date_period,
 	Frequency,
 )
 
 
 class TestSimpleSubscription(unittest.TestCase):
-	def test_get_first_day_of_period(self):
-		from_date = date(2022, 11, 7)
+	def test_get_calendar_period(self):
+		eval_date = date(2022, 11, 7)
 
-		invoice_date = get_first_day_of_period(from_date, Frequency.Monthly)
-		self.assertEqual(invoice_date, date(2022, 11, 1))
+		from_date, to_date = get_calendar_period(eval_date, Frequency.Monthly)
+		self.assertEqual(from_date, date(2022, 11, 1))
+		self.assertEqual(to_date, date(2022, 11, 30))
 
-		invoice_date = get_first_day_of_period(from_date, Frequency.Quarterly)
-		self.assertEqual(invoice_date, date(2022, 10, 1))
+		from_date, to_date = get_calendar_period(eval_date, Frequency.Quarterly)
+		self.assertEqual(from_date, date(2022, 10, 1))
+		self.assertEqual(to_date, date(2022, 12, 31))
 
-		invoice_date = get_first_day_of_period(from_date, Frequency.Halfyearly)
-		self.assertEqual(invoice_date, date(2022, 7, 1))
+		from_date, to_date = get_calendar_period(eval_date, Frequency.Halfyearly)
+		self.assertEqual(from_date, date(2022, 7, 1))
+		self.assertEqual(to_date, date(2022, 12, 31))
 
-		invoice_date = get_first_day_of_period(from_date, Frequency.Yearly)
-		self.assertEqual(invoice_date, date(2022, 1, 1))
+		from_date, to_date = get_calendar_period(eval_date, Frequency.Yearly)
+		self.assertEqual(from_date, date(2022, 1, 1))
+		self.assertEqual(to_date, date(2022, 12, 31))
+
+def test_get_date_period(self):
+		eval_date = date(2022, 11, 7)
+		initial_date = date(2022, 6, 25)
+
+		from_date, to_date = get_date_period(eval_date, Frequency.Monthly, initial_date)
+		self.assertEqual(from_date, date(2022, 10, 25))
+		self.assertEqual(to_date, date(2022, 11, 24))
+
+		from_date, to_date = get_date_period(eval_date, Frequency.Quarterly, initial_date)
+		self.assertEqual(from_date, date(2022, 9, 25))
+		self.assertEqual(to_date, date(2022, 12, 24))
+
+		from_date, to_date = get_date_period(eval_date, Frequency.Halfyearly, initial_date)
+		self.assertEqual(from_date, date(2022, 6, 25))
+		self.assertEqual(to_date, date(2022, 12, 24))
+
+		from_date, to_date = get_date_period(eval_date, Frequency.Yearly, initial_date)
+		self.assertEqual(from_date, date(2022, 6, 25))
+		self.assertEqual(to_date, date(2023, 6, 24))
+

--- a/simple_subscription/simple_subscription/doctype/simple_subscription/test_simple_subscription.py
+++ b/simple_subscription/simple_subscription/doctype/simple_subscription/test_simple_subscription.py
@@ -8,7 +8,10 @@ from datetime import date
 from .simple_subscription import (
 	get_calendar_period,
 	get_date_period,
+	get_from_and_to_date,
 	Frequency,
+	PeriodType,
+	BillingTime,
 )
 
 
@@ -52,3 +55,54 @@ class TestSimpleSubscription(unittest.TestCase):
 		self.assertEqual(from_date, date(2022, 6, 25))
 		self.assertEqual(to_date, date(2023, 6, 24))
 
+	def test_get_from_and_to_date(self):
+		from_date, to_date = get_from_and_to_date(
+			frequency=Frequency.Monthly,
+			period_type=PeriodType.CalendarMonths,
+			billing_time=BillingTime.AtBeginningOfPeriod,
+			eval_date=date(2022, 11, 7),
+			start_date=date(2022, 11, 7),
+		)
+		self.assertEqual(from_date, date(2022, 11, 1))
+		self.assertEqual(to_date, date(2022, 11, 30))
+
+		from_date, to_date = get_from_and_to_date(
+			frequency=Frequency.Monthly,
+			period_type=PeriodType.CalendarMonths,
+			billing_time=BillingTime.AfterEndOfPeriod,
+			eval_date=date(2022, 11, 7),
+			start_date=date(2022, 10, 1),
+		)
+		self.assertEqual(from_date, date(2022, 10, 1))
+		self.assertEqual(to_date, date(2022, 10, 31))
+
+		# previous behavior should be the default
+		from_date, to_date = get_from_and_to_date(
+			frequency=Frequency.Monthly,
+			period_type=None,
+			billing_time=None,
+			eval_date=date(2022, 11, 7),
+			start_date=date(2022, 10, 1),
+		)
+		self.assertEqual(from_date, date(2022, 10, 1))
+		self.assertEqual(to_date, date(2022, 10, 31))
+
+		from_date, to_date = get_from_and_to_date(
+			frequency=Frequency.Monthly,
+			period_type=PeriodType.StartDate,
+			billing_time=BillingTime.AtBeginningOfPeriod,
+			eval_date=date(2022, 11, 7),
+			start_date=date(2022, 11, 5),
+		)
+		self.assertEqual(from_date, date(2022, 11, 5))
+		self.assertEqual(to_date, date(2022, 12, 4))
+
+		from_date, to_date = get_from_and_to_date(
+			frequency=Frequency.Monthly,
+			period_type=PeriodType.StartDate,
+			billing_time=BillingTime.AfterEndOfPeriod,
+			eval_date=date(2022, 11, 7),
+			start_date=date(2022, 10, 5),
+		)
+		self.assertEqual(from_date, date(2022, 10, 5))
+		self.assertEqual(to_date, date(2022, 11, 4))

--- a/simple_subscription/utils.py
+++ b/simple_subscription/utils.py
@@ -1,0 +1,29 @@
+import frappe
+from frappe.utils import now_datetime
+from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
+
+
+def before_tests():
+	# complete setup if missing
+	year = now_datetime().year
+	if not frappe.get_list("Company"):
+		setup_complete(
+			{
+				"currency": "EUR",
+				"full_name": "Test User",
+				"company_name": "Bolt Trades",
+				"timezone": "Europe/Berlin",
+				"company_abbr": "BT",
+				"industry": "Manufacturing",
+				"country": "Germany",
+				"fy_start_date": f"{year}-01-01",
+				"fy_end_date": f"{year}-12-31",
+				"language": "english",
+				"company_tagline": "Testing",
+				"email": "test@erpnext.com",
+				"password": "test",
+				"chart_of_accounts": "Standard",
+			}
+		)
+
+	frappe.db.commit()  # nosemgrep


### PR DESCRIPTION
contains two new features:
- added support for billing at the beginning of a period
- added support for billing periods that are based on start date (e.g. do not follow calendar months)

further details:
- should be backwards compatbile to version 15.0.0 (without the new select fields)
- Button "Create invoice for last period" is no "create invoice for current period", acting the same then before but extended to the new cases
- refactor of the function "get_first_day_of_period": now always returns a period (from_date, to_date), calculation simplified, function name changed to "get_calendar_period" since it is more fitting